### PR TITLE
Fix custom modules group sync rule not showing up

### DIFF
--- a/src/components/sections/GroupSyncSection.tsx
+++ b/src/components/sections/GroupSyncSection.tsx
@@ -2,7 +2,6 @@ import {DebugData} from "../../types/DebugData";
 import FloatingSection, {FloatingContent} from "../FloatingSection";
 import {faSyncAlt} from "@fortawesome/free-solid-svg-icons";
 import {goToModule} from "../../utils";
-import {GroupSyncRule} from "../../types/GroupSyncRule";
 import BooleanBadge from "../utils/BooleanBadge";
 import Empty from "../utils/Empty";
 
@@ -50,20 +49,6 @@ function GroupSyncSection({
         },
     };
 
-    // TODO: yuck. can't find a way to access `rule[injector.column_name]` without TS error, so have to do this
-    const getGroupIdFromColumnName = (rule: GroupSyncRule, columnName: string): string => {
-        switch (columnName) {
-            case 'website_group_id':
-                return rule.website_group_id;
-            case 'ingame_rank_name':
-                return rule.ingame_rank_name;
-            case 'discord_role_id':
-                return rule.discord_role_id;
-            default:
-                return ''; // should never happen
-        }
-    }
-
     const rulesFloatingContent: FloatingContent = {
         subheadingKey: 'group_sync_section.rules',
         table: {
@@ -85,7 +70,7 @@ function GroupSyncSection({
                             body: rule.id,
                         },
                         ...debugData.namelessmc.settings.group_sync.injectors.map(injector => {
-                            const group_id = getGroupIdFromColumnName(rule, injector.column_name);
+                            const group_id = rule[injector.column_name];
                             if (injector.column_name === 'website_group_id') {
                                 return {
                                     body: Object.values(debugData.namelessmc.groups).find(g => String(g.id) === group_id)?.name ?? '',

--- a/src/types/GroupSyncRule.ts
+++ b/src/types/GroupSyncRule.ts
@@ -1,4 +1,5 @@
 export interface GroupSyncRule {
+    [key: string]: any;
     id: number;
     ingame_rank_name: string;
     discord_role_id: string;


### PR DESCRIPTION
The typing didn't allow to index the group sync rules by string. This didn't allow custom modules to show up. This PR fixes that